### PR TITLE
Add Umami analytics tracking

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -6,6 +6,7 @@
   <title>AMB — Agent Memory Benchmark</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400&family=Space+Grotesk:wght@500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script async src="https://analytics.hindsight.vectorize.io/script.js" data-website-id="d018abae-77ea-464d-a89d-404b1b305425"></script>
 </head>
 <body>
   <div id="app"></div>


### PR DESCRIPTION
## Summary
- Adds Umami analytics script to `ui/index.html`
- Tracks pageviews across all routes (Umami handles SPA navigation via the History API automatically)

## Test plan
- [x] Verified script loads and sends pageview events via browser DevTools Network tab