### PR TITLE
fix: rebuild UI dist to include Umami analytics script

### DIFF
--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -6,6 +6,7 @@
   <title>AMB — Agent Memory Benchmark</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400&family=Space+Grotesk:wght@500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script async src="https://analytics.hindsight.vectorize.io/script.js" data-website-id="d018abae-77ea-464d-a89d-404b1b305425"></script>
   <script type="module" crossorigin src="/assets/index-Bkpcjn4U.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-D7Rc4QVa.css">
 </head>


### PR DESCRIPTION
## Summary
- `ui/dist/index.html` was not rebuilt after the Umami script tag was added in #1
- Vercel has an empty `buildCommand`, so it serves the committed `dist/` directly — the stale built file was missing the tracking script
- Rebuilt `ui/dist` so the Umami script tag is now present in the deployed HTML

## Test plan
- [ ] Verify `<script async src="https://analytics.hindsight.vectorize.io/script.js" ...>` is present in the deployed page source at agentmemorybenchmark.ai
- [ ] Confirm events appear in the Umami dashboard after deployment