### PR TITLE
fix: add user_ids kwarg to LoCoMo / MemBench / MemSim / PersonaMem load_documents

### DIFF
--- a/src/memory_bench/dataset/locomo.py
+++ b/src/memory_bench/dataset/locomo.py
@@ -284,6 +284,7 @@ If it's correct, set correct=true.
         category: str | None = None,
         limit: int | None = None,
         ids: set[str] | None = None,
+        user_ids: set[str] | None = None,
     ) -> list[Document]:
         data = self._load_raw()
         documents: list[Document] = []
@@ -294,6 +295,8 @@ If it's correct, set correct=true.
         for item in data:
             sample_id = item["sample_id"]
             if conv_filter is not None and sample_id != conv_filter:
+                continue
+            if user_ids is not None and sample_id not in user_ids:
                 continue
             conv = item["conversation"]
             speaker_a = conv.get("speaker_a", "A")

--- a/src/memory_bench/dataset/membench.py
+++ b/src/memory_bench/dataset/membench.py
@@ -145,6 +145,7 @@ class MemBenchDataset(Dataset):
         category: str | None = None,
         limit: int | None = None,
         ids: set[str] | None = None,
+        user_ids: set[str] | None = None,
     ) -> list[Document]:
         trajectories = self._load_trajectories(split)
         documents: list[Document] = []

--- a/src/memory_bench/dataset/memsim.py
+++ b/src/memory_bench/dataset/memsim.py
@@ -139,6 +139,7 @@ class MemSimDataset(Dataset):
         category: str | None = None,
         limit: int | None = None,
         ids: set[str] | None = None,
+        user_ids: set[str] | None = None,
     ) -> list[Document]:
         trajectories = self._load_trajectories(split)
         documents: list[Document] = []

--- a/src/memory_bench/dataset/personamem.py
+++ b/src/memory_bench/dataset/personamem.py
@@ -284,6 +284,7 @@ class PersonaMemDataset(Dataset):
         category: str | None = None,
         limit: int | None = None,
         ids: set[str] | None = None,
+        user_ids: set[str] | None = None,
     ) -> list[Document]:
         sessions_by_ctx = self._load_sessions(split)
         documents: list[Document] = []


### PR DESCRIPTION
## Summary

Fixes the upstream `TypeError: LoComoDataset.load_documents() got an unexpected keyword argument 'user_ids'` raised by the standard `omb run --dataset locomo --memory bm25 --split locomo10 --query-limit N` command at commit `45fa380`.

Companion to the issue filed alongside this PR.

## Root cause

`Dataset.load_documents()` ([base.py#L81-L92](https://github.com/vectorize-io/agent-memory-benchmark/blob/main/src/memory_bench/dataset/base.py#L81-L92)) declares `user_ids: set[str] | None = None` in its abstract signature. The runner at [runner.py#L128](https://github.com/vectorize-io/agent-memory-benchmark/blob/main/src/memory_bench/runner.py#L128) passes `user_ids=` to `dataset.load_documents()` whenever the dataset has an `isolation_unit` AND a `query_limit` is set.

4 of 7 concrete dataset overrides forgot to include the kwarg:

| Dataset | `user_ids` in override before this PR? | `isolation_unit` | Bug fires today? |
|---|---|---|---|
| `LoComoDataset` | ❌ | `'conversation'` | **YES** |
| `MemBenchDataset` | ❌ | `None` | latent |
| `MemSimDataset` | ❌ | `None` | latent |
| `PersonaMemDataset` | ❌ | `None` | latent |
| `LongMemEvalDataset` | ✅ | `'question'` | — |
| `LifeBenchDataset` | ✅ | `'user'` | — |
| `BEAMDataset` | ✅ | `'conversation'` | — |

## Changes

- **LoCoMo**: add `user_ids` to signature **and** apply the filter `if user_ids is not None and sample_id not in user_ids: continue`. Matches the existing pattern in `BEAMDataset` / `LongMemEvalDataset` / `LifeBenchDataset` (which filter by their per-doc identifier).
- **MemBench / MemSim / PersonaMem**: signature-only fixes. Their `isolation_unit=None` means the runner never passes them `user_ids` today, so adding filter logic without a trigger path would be premature. Signature parity with the base class is restored.

Total diff: +6 lines across 4 files.

## Test plan

- [x] Live-validated: `omb run --dataset locomo --memory bm25 --split locomo10 --query-limit 3` no longer raises `TypeError` and progresses to answer-generation.
- [ ] Existing dataset test suite (please run on your CI).

Happy to address any review feedback.