### PR TITLE
chore(security): fix nanoid, postcss, unhead advisories in ui/package-lock.json

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1018,6 +1018,64 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
@@ -1071,13 +1129,13 @@
       "license": "MIT"
     },
     "node_modules/@unhead/vue": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.12.tgz",
-      "integrity": "sha512-zEWqg0nZM8acpuTZE40wkeUl8AhIe0tU0OkilVi1D4fmVjACrwoh5HP6aNqJ8kUnKsoy6D+R3Vi/O+fmdNGO7g==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.17.tgz",
+      "integrity": "sha512-pnC8x9HLV3qQXdvWfylUEU25uhfCAy3ly9nmpQz84j9py818DRfU8jOsQ5wjdWtxyU1vX/fW2udfm4jtxUK8Bg==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1",
-        "unhead": "2.1.12"
+        "unhead": "2.1.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
@@ -1332,9 +1390,9 @@
       "license": "ISC"
     },
     "node_modules/hookable": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.0.tgz",
-      "integrity": "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "license": "MIT"
     },
     "node_modules/jiti": {
@@ -1614,9 +1672,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -1638,9 +1696,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1657,7 +1715,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1748,9 +1806,9 @@
       }
     },
     "node_modules/unhead": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.12.tgz",
-      "integrity": "sha512-iTHdWD9ztTunOErtfUFk6Wr11BxvzumcYJ0CzaSCBUOEtg+DUZ9+gnE99i8QkLFT2q1rZD48BYYGXpOZVDLYkA==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.17.tgz",
+      "integrity": "sha512-HLMKXOszRhAPBrr6VlqCeVeJq2kbC4kXwzGLEZvvojPLWNYTJw22xG7Bfwhsvs31+IBet3Wl8ADg9dwYdyphfQ==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1"


### PR DESCRIPTION
Daily security sweep — `ui/` npm bundle.

Fixes 4 of the 6 advisories `npm audit` reports for `ui/package-lock.json`. **Lockfile-only: `ui/package.json` is unchanged.** All three packages had a fixed version already inside the ranges the existing manifest declares, so no direct bump and no `overrides` entry was needed.

### Advisories fixed

| package | direct/transitive | before | after | GHSA |
|---|---|---|---|---|
| `nanoid` | transitive (via `postcss`) | 3.3.11 | **3.3.18** | GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8 |
| `postcss` | transitive (via `vite`) | 8.5.8 | **8.5.26** | GHSA-qx2v-qp2m-jg93, GHSA-6g55-p6wh-862q, GHSA-fxqj-rqcc-2cmp, GHSA-r28c-9q8g-f849 |
| `unhead` | transitive (pinned exactly by `@unhead/vue`) | 2.1.12 | **2.1.17** | GHSA-95h2-gj7x-gx9w |
| `@unhead/vue` | direct (`^2.1.12`) | 2.1.12 | **2.1.17** | — (flagged for depending on vulnerable `unhead`) |

3 high (`nanoid`, `postcss`) and 1 moderate (`unhead` / `@unhead/vue`) resolved. `hookable` 6.1.0 → 6.1.1 comes along as `@unhead/vue`'s own in-range dependency.

Why no manifest change was needed:
- `postcss` 8.5.26 satisfies `vite@5.4.21`'s declared `postcss: ^8.4.43`.
- `nanoid` 3.3.18 satisfies `postcss@8.5.26`'s declared `nanoid: ^3.3.17`.
- `@unhead/vue` 2.1.17 satisfies the manifest's declared `^2.1.12`, and `@unhead/vue` pins `unhead` exactly, so `unhead` moves with it.

### Not fixed here — `vite` / `esbuild` (deliberately excluded)

`npm audit`'s only offered fix for this pair is `npm audit fix --force`, which installs **`vite@8.2.2` — three major versions up**. This sweep does not force resolves, so the pair is left alone and tracked in #39 instead:

- `esbuild` <= 0.24.2 — GHSA-67mh-4wv8-2f99 (moderate)
- `vite` <= 6.4.2 — GHSA-fx2h-pf6j-xcff (high), GHSA-4w7w-66w2-5vf9 (moderate), GHSA-v6wh-96g9-6wx3 (moderate)

There is no in-range fix: `vite` 5.x tops out at 5.4.21 (what is installed) and the whole 5.x line stays inside the vulnerable range, so escaping it is necessarily a major bump. See #39 for the analysis — the minimal escape is `vite@^6.4.3`, not the `8.2.2` npm suggests.

### About the `@tailwindcss/oxide-wasm32-wasi` block in the diff

58 of the 75 added lines are six `inBundle: true, optional: true` entries under `node_modules/@tailwindcss/oxide-wasm32-wasi/`. **These are not part of the security change.** They are npm 10.9.8 renormalizing bundled optional dependencies, and running a no-op `npm install --package-lock-only` on untouched `main` produces the exact same 58 lines. They carry no `resolved`/`integrity`, so they add no new downloads. Verified before committing so the churn could be accounted for rather than hidden.

### Verification — local only

**This repository has no CI.** There is no `.github/workflows` directory at all, so nothing will run against this branch. Everything below was run locally on the branch, and the same steps were run first on untouched `main` to establish a baseline. `ui/package.json` defines only `dev` / `build` / `preview` — there is no `test` and no `lint` script, so those steps do not exist here.

| step | `main` (baseline) | this branch |
|---|---|---|
| `npm ci` | exit 0 — 56 packages | exit 0 |
| `npm run build` (`vite build`) | **exit 0** — 71 modules, built in 751 ms | **exit 0** — 71 modules, built in 769 ms |
| `npm audit --package-lock-only` | 6 vulns (3 high, 3 moderate) | **2 vulns (1 high, 1 moderate)** |

The baseline was already green, so this is a true pass rather than a differential comparison. Module count is identical (71 → 71); the CSS chunk hash is unchanged and the JS chunk moves 226.71 kB → 227.42 kB, consistent with the `unhead` patch bump.

Node v22.22.3, npm 10.9.8, macOS arm64.

Built `ui/dist/` is checked into this repo. It was **deliberately not regenerated** here — this PR touches `ui/package-lock.json` and nothing else, so the committed `dist/` is left exactly as it is on `main`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
